### PR TITLE
Add simple phone call agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,17 @@ Start the application
 python src/app/app.py
 ```
 
+### Minimal phone call agent
+
+If you do not need the web frontend, you can run a simplified service that only
+connects your Azure Communication Services phone number with the Azure Realtime API:
+
+```bash
+python scripts/simple_agent.py
+```
+
+The script expects the same environment variables used by `src/app/app.py`.
+
 To make inbound calls work for local development, you need to [set up another Event Grid System Topic](#forward-inbound-calls-to-your-application) and set the Web Socket endpoint to your ngrok domain (e.g. `https://1234-567-123-456-789/acs/incoming`).
 
 ## Customization

--- a/scripts/simple_agent.py
+++ b/scripts/simple_agent.py
@@ -1,0 +1,54 @@
+import os
+import logging
+from aiohttp import web
+from dotenv import load_dotenv
+from azure.core.credentials import AzureKeyCredential
+
+from src.app.backend.azure import get_azure_credentials
+from src.app.backend.acs import AcsCaller
+from src.app.backend.rtmt import RTMiddleTier
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("simple_agent")
+
+async def create_app():
+    load_dotenv()
+
+    azure_credentials = get_azure_credentials(os.environ.get("AZURE_TENANT_ID"))
+
+    llm_endpoint = os.environ["AZURE_OPENAI_ENDPOINT"]
+    llm_deployment = os.environ["AZURE_OPENAI_COMPLETION_DEPLOYMENT_NAME"]
+    llm_key = os.environ.get("AZURE_OPENAI_API_KEY")
+    llm_credential = azure_credentials if not llm_key else AzureKeyCredential(llm_key)
+
+    rtmt = RTMiddleTier(llm_endpoint, llm_deployment, llm_credential)
+    rtmt.system_message = "You are a helpful voice assistant."
+
+    acs_source_number = os.environ["ACS_SOURCE_NUMBER"]
+    acs_connection_string = os.environ["ACS_CONNECTION_STRING"]
+    acs_callback_path = os.environ["ACS_CALLBACK_PATH"]
+    acs_media_streaming_websocket_path = os.environ["ACS_MEDIA_STREAMING_WEBSOCKET_PATH"]
+
+    caller = AcsCaller(
+        acs_source_number,
+        acs_connection_string,
+        acs_callback_path,
+        acs_media_streaming_websocket_path,
+    )
+
+    async def websocket_handler_acs(request: web.Request):
+        ws = web.WebSocketResponse()
+        await ws.prepare(request)
+        await rtmt.forward_messages(ws, True)
+        return ws
+
+    app = web.Application()
+    app.router.add_post("/acs/incoming", caller.inbound_call_handler)
+    app.router.add_get("/realtime-acs", websocket_handler_acs)
+
+    return app
+
+if __name__ == "__main__":
+    host = os.getenv("HOST", "0.0.0.0")
+    port = int(os.getenv("PORT", 8765))
+    web.run_app(create_app(), host=host, port=port)


### PR DESCRIPTION
## Summary
- add `scripts/simple_agent.py` for minimal ACS-to-Azure Realtime API usage
- document how to run the minimal agent in README

## Testing
- `python -m py_compile scripts/simple_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_68526eee6d6483288ecf955812d87a85